### PR TITLE
Fix unreliable ESLint and typechecking

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,5 +6,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 reuse lint
+yarn turbo type-check
 yarn turbo test
 yarn turbo lint

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,3 +23,5 @@ changesetIgnorePatterns:
   - '**/*.spec.{js,ts}'
 
 yarnPath: .yarn/releases/yarn-4.0.0-rc.27.cjs
+
+enableTelemetry: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,18 @@
+packageExtensions:
+  '@graphql-codegen/cli@*':
+    peerDependencies:
+      '@types/node': '^18'
+      ts-node: '^10'
+      typescript: '~4.8.4'
+  '@graphql-eslint/eslint-plugin@*':
+    peerDependencies:
+      '@types/node': '^18'
+      typescript: '~4.8.4'
+  graphql-config@*:
+    peerDependencies:
+      '@types/node': '^18'
+      typescript: '~4.8.4'
+
 changesetBaseRefs:
   - main
   - origin/main

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -7,9 +7,9 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
+    "type-check": "tsc --noEmit",
     "start": "next start",
-    "test": "jest",
-    "lint:types": "tsc --noEmit"
+    "test": "jest"
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",

--- a/apps/nextjs-gh-pages/package.json
+++ b/apps/nextjs-gh-pages/package.json
@@ -7,8 +7,8 @@
     "dev": "next",
     "build": "next build && next export",
     "deploy": "next build && touch out/.nojekyll && git add out/ && git commit -m \"ci(gh-pages): deploy\" && git subtree push --prefix out origin gh-pages",
-    "lint": "yarn lint:types && next lint",
-    "lint:types": "tsc --noEmit"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "clsx": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "husky install",
     "dev": "dotenv -- turbo run dev --parallel",
     "lint": "turbo run lint",
+    "type-check": "turbo run type-check",
     "test": "turbo run test",
     "clean": "turbo run clean",
     "build": "turbo run build",

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -14,4 +14,12 @@ module.exports = {
     // https://github.com/typescript-eslint/typescript-eslint/issues/131
     'no-undef': 0,
   },
+  overrides: [
+    {
+      files: ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
+      rules: {
+        'import/no-anonymous-default-export': 'off',
+      },
+    },
+  ],
 }

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -3,7 +3,7 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
-    "lib": ["ES2015"],
+    "lib": ["ESNext"],
     "module": "ESNext",
     "target": "ES6",
     "jsx": "react-jsx"

--- a/packages/ui/.eslintignore
+++ b/packages/ui/.eslintignore
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Temple University
+# SPDX-License-Identifier: CC0-1.0
+
+build
+result
+dist/
+node_modules/
+coverage

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,5 +1,15 @@
 module.exports = {
   root: true,
   extends: ['custom'],
-  overrides: [],
+  rules: {
+    '@next/next/no-html-link-for-pages': 'off',
+  },
+  overrides: [
+    {
+      files: ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
+      rules: {
+        'import/no-anonymous-default-export': 'off',
+      },
+    },
+  ],
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external react && tailwindcss -i ./src/styles.css -o ./dist/styles.css",
     "dev": "concurrently \"tsup src/index.ts --format esm,cjs --dts --external react --watch\" \"tailwindcss -i ./src/styles.css -o ./dist/styles.css --watch\"",
+    "type-check": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,11 +12,13 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external react && tailwindcss -i ./src/styles.css -o ./dist/styles.css",
     "dev": "concurrently \"tsup src/index.ts --format esm,cjs --dts --external react --watch\" \"tailwindcss -i ./src/styles.css -o ./dist/styles.css --watch\"",
+    "lint": "eslint --ext=js,jsx,ts,tsx,cjs,mjs .",
     "type-check": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "dependencies": {
     "clsx": "^1.2.1",
+    "next": "^13.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -27,6 +29,7 @@
     "concurrently": "^7.2.2",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",
+    "eslint-plugin-tailwindcss": "^3.6.2",
     "rimraf": "^3.0.2",
     "tailwind-config": "workspace:*",
     "tailwindcss": "^3.1.5",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build", "^codegen"],
-      "outputs": ["dist/**", ".next/**", "build/**"]
+      "outputs": ["dist/**", ".next/**", "build/**", "out/**"]
     },
     "codegen": {
       "outputs": ["graphql/generated/**"]

--- a/turbo.json
+++ b/turbo.json
@@ -8,8 +8,13 @@
     "codegen": {
       "outputs": ["graphql/generated/**"]
     },
-    "lint": {
+    "type-check": {
       "dependsOn": ["^build"],
+      "inputs": ["*.tsx", "*.ts"],
+      "outputs": []
+    },
+    "lint": {
+      "dependsOn": ["^type-check", "^build"],
       "outputs": []
     },
     "test": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10817,7 +10817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -12709,6 +12709,7 @@ __metadata:
     concurrently: "npm:^7.2.2"
     eslint: "npm:^7.32.0"
     eslint-config-custom: "workspace:*"
+    eslint-plugin-tailwindcss: "npm:^3.6.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     rimraf: "npm:^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12710,6 +12710,7 @@ __metadata:
     eslint: "npm:^7.32.0"
     eslint-config-custom: "workspace:*"
     eslint-plugin-tailwindcss: "npm:^3.6.2"
+    next: "npm:^13.0.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     rimraf: "npm:^3.0.2"


### PR DESCRIPTION
- ci(builds): standardise on `type-check` instead of `lint:types`
- chore(deps|gql): appease badly-specified lib dependencies
- fix(ui|eslint|tsc): ensure checks run on `ui` package
- chore: disable yarn telemetry
- fix(ui|tsc): target `ESNext` not `ES2015`
- chore(builds): add `out/**` to `build` outputs
