### PR TITLE
fix(theme): swap css import order to work around bad turborepo example

### DIFF
--- a/apps/nextjs-minimal/pages/_app.tsx
+++ b/apps/nextjs-minimal/pages/_app.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Temple University <kleinweb@temple.edu>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import '../styles/globals.css'
 import 'ui/styles.css'
+import '../styles/globals.css'
 
 import type { AppProps } from 'next/app'
 


### PR DESCRIPTION
see the following upstream discussions:

https://github.com/vercel/turbo/issues/1809
https://github.com/vercel/turbo/issues/2554
https://github.com/vercel/turbo/discussions/2308
