### PR TITLE
Restore alternate wording for CTA links

### DIFF
--- a/apps/nextjs-minimal/pages/index.tsx
+++ b/apps/nextjs-minimal/pages/index.tsx
@@ -89,7 +89,7 @@ export default function Home() {
                   target="_blank"
                 >
                   <Button>
-                    Listen Now
+                    Listen Now on WHYY
                     <ExternalLink className="relative bottom-[0.5px] -mr-1 py-1 pl-1" />
                   </Button>
                 </Link>
@@ -168,7 +168,7 @@ export default function Home() {
                   target="_blank"
                 >
                   <Button>
-                    Read more
+                    Read more on Billy Penn
                     <ExternalLink className="relative bottom-[0.5px] -mr-1 py-1 pl-1" />
                   </Button>
                 </Link>


### PR DESCRIPTION
This reverts commit b30bff1d39eb3b35be41cfa503209e3b0ee05afc.
