### PR TITLE
fix(env:vscode|lint|deps): configurate extensions for `yarn` not `npm`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,9 @@
   },
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.formatOnSave": true,
+  "npm.packageManager": "yarn",
+  "stylelint.packageManager": "yarn",
+  "eslint.packageManager": "yarn"
 }


### PR DESCRIPTION
cherry-picked from #97 