### PR TITLE
fix(urls): restore disabling of trailing slashes

### DIFF
--- a/apps/nextjs/next.config.js
+++ b/apps/nextjs/next.config.js
@@ -105,7 +105,7 @@ const nextConfig = {
   // > buggy.
   //
   // <https://github.com/Automattic/vip-go-nextjs-skeleton/tree/example/custom-server-trailing-slash>
-  // trailingSlash: false,
+  trailingSlash: false,
 
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
this setting was commented out while debugging other url issues
